### PR TITLE
Add ability to override consul endpoint

### DIFF
--- a/lib/config_reader.js
+++ b/lib/config_reader.js
@@ -1,4 +1,4 @@
-var consul = require('consul')();
+var consul = require('consul')({'host': global.endpoint}); 
 
 var _ = require('underscore');
 
@@ -17,7 +17,6 @@ exports.read = function(params, cb) {
   if (process.env.TOKEN) {
     params = _.extend(params, {'token': process.env.TOKEN})
   }
-
   consul.kv.get(params, function(err, item) {
     if (err) return cb(err);
 
@@ -56,4 +55,8 @@ exports.wait = function(cb) {
 
     process.nextTick(wait_for_change);
   });
+};
+
+exports.setConsul = function(newConsul) {
+	consul = newConsul;
 };

--- a/lib/config_reader.js
+++ b/lib/config_reader.js
@@ -56,7 +56,3 @@ exports.wait = function(cb) {
     process.nextTick(wait_for_change);
   });
 };
-
-exports.setConsul = function(newConsul) {
-	consul = newConsul;
-};

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -3,7 +3,7 @@ var path = require('path');
 
 var logger = require('../logging.js');
 
-var consul = require('consul')();
+var consul = require('consul')({'host': global.endpoint});
 
 var token = undefined;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,8 +68,6 @@ config_reader.read(function(err, config) {
     config.local_store = os.tmpdir();
   }
 
-  config.endpoint = endpoint;
-
   logger.info('git2consul is running');
 
   process.on('uncaughtException', function(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,32 @@
 var logging = require('./logging.js');
-var config_reader = require('./config_reader.js');
 
 var fs = require('fs');
 var os = require('os');
 
 /**
+ * First, check if there is a command line override for the consul endpoint
+ * If so, use it to grab the config
+ */
+
+global.endpoint = "127.0.0.1";
+
+for (var i=2; i<process.argv.length; ++i) {
+	if(process.argv[i] === '-e' || process.argv[i] === '--endpoint') {
+		if(i+1 >= process.argv.length) {
+			logger.error("No endpoint provided with --endpoint option");
+			process.exit(3);
+		}
+		global.endpoint = process.argv[i+1];
+	}
+}
+
+var config_reader = require('./config_reader.js');
+/**
  * Read config from a specially named Consul resource.  If the config was not seeded
  * (and this should be done using utils/config_seeder.js), git2consul will not boot.
  */
+
+
 config_reader.read(function(err, config) {
 
   if (err) return console.error(err);
@@ -48,6 +67,8 @@ config_reader.read(function(err, config) {
   if (!config.local_store) {
     config.local_store = os.tmpdir();
   }
+
+  config.endpoint = endpoint;
 
   logger.info('git2consul is running');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,12 +21,11 @@ for (var i=2; i<process.argv.length; ++i) {
 }
 
 var config_reader = require('./config_reader.js');
+
 /**
  * Read config from a specially named Consul resource.  If the config was not seeded
  * (and this should be done using utils/config_seeder.js), git2consul will not boot.
  */
-
-
 config_reader.read(function(err, config) {
 
   if (err) return console.error(err);


### PR DESCRIPTION
We want to run git2consul on one of our Consul server nodes. They are all setup to use their eth0 IP for HTTP calls (as we want to expose the web interface on each node as well, and it binds to the same address as the HTTP interface). So I added a command-line option to override the host which git2consul should talk to.

This also opens up the possibility of running git2consul on its own server if you wanted to.