### PR TITLE
F expand keys

### DIFF
--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -58,7 +58,7 @@ var create_key_name = function(branch, file, ref) {
  * For example, the obj { 'first': { 'second': { 'third' : 'whee' }}} should yield a
  * parts array with a single entry: 'first/second/third' with value 'whee'.
  */
-function render_obj(parts, prefix, obj) {
+var render_obj = function(parts, prefix, obj) {
 
   _.mapObject(obj, function(val, key) {
     if (_.isArray(val)) return;

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -63,9 +63,9 @@ var render_obj = function(parts, prefix, obj) {
   _.mapObject(obj, function(val, key) {
     if (_.isArray(val)) return;
 
-    if (_.isObject(val)) return render_obj(parts, prefix + '/' + key, val)
+    if (_.isObject(val)) return render_obj(parts, prefix + '/' + encodeURIComponent(key), val)
 
-    parts.push({'key': prefix + '/' + key, 'value': val});
+    parts.push({'key': prefix + '/' + encodeURIComponent(key), 'value': val});
   });
 }
 

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -8,6 +8,12 @@ var consul = require('consul')({'host': global.endpoint});
 
 var token = undefined;
 
+// This makes life a bit easier for expand_keys mode, allowing us to check for a .json
+// extension with less code per line.
+String.prototype.endsWith = function(suffix) {
+  return this.indexOf(suffix, this.length - suffix.length) !== -1;
+};
+
 /* istanbul ignore next */
 exports.setToken = function(tok) {
   token = tok;

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -40,11 +40,6 @@ var create_key_name = function(branch, file, ref) {
     key_parts.push(branch.name);
   }
 
-  if (branch.expand_keys && file.endsWith('.json')) {
-    // If we are in expand_keys mode and this file is a .json, strip that from the name.
-    file = file.substring(0, file.length-5);
-  }
-
   // Finish with the file path
   key_parts.push(file);
   return key_parts.join('/');

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
 
@@ -32,9 +33,54 @@ var create_key_name = function(branch, file, ref) {
   if (branch.include_branch_name && !ref) {
     key_parts.push(branch.name);
   }
+
+  if (branch.expand_keys && file.endsWith('.json')) {
+    // If we are in expand_keys mode and this file is a .json, strip that from the name.
+    file = file.substring(0, file.length-5);
+  }
+
   // Finish with the file path
   key_parts.push(file);
   return key_parts.join('/');
+};
+
+
+/**
+ * Given an obj, recurse into it, populating the parts array with all of the key->value
+ * relationships, prefixed by parent objs.
+ * 
+ * For example, the obj { 'first': { 'second': { 'third' : 'whee' }}} should yield a
+ * parts array with a single entry: 'first/second/third' with value 'whee'.
+ */
+function render_obj(parts, prefix, obj) {
+
+  _.mapObject(obj, function(val, key) {
+    if (_.isArray(val)) return;
+
+    if (_.isObject(val)) return render_obj(parts, prefix + '/' + key, val)
+
+    parts.push({'key': prefix + '/' + key, 'value': val});
+  });
+}
+
+/**
+ * Walk through obj, creating a Consul write operation for each kv pair.  Objects are treated
+ * as parents of subtrees.  Arrays are ignored since they add annoying problems (multiple array
+ * entries can have the same value, so what do we do then?).
+ */
+var populate_kvs_from_json = function(branch, prefix, obj, cb) {
+
+  var writes = [];
+
+  render_obj(writes, prefix, obj);
+
+  logger.debug('JSON file %s yielded %s keys', prefix, writes.length);
+
+  cb = _.after(writes.length, cb);
+
+  writes.forEach(function(write) {
+    write_content_to_consul(write.key, write.value, cb);
+  });
 };
 
 /**
@@ -46,12 +92,33 @@ var file_modified = function(branch, file, cb) {
 
   logger.trace('Attempting to read "%s"', fqf);
 
-  fs.readFile(fqf, {encoding:'utf8'}, function(err, body) {
-    /* istanbul ignore if */
-    if (err) return cb('Failed to read key ' + fqf + ' due to ' + err);
-    var body = body ? body.trim() : '';
-    write_content_to_consul(create_key_name(branch, file), body, cb);
-  });
+  if (branch.expand_keys && file.endsWith('.json')) {
+    // Delete current tree.  Yeah, I know this is kinda the coward's way out, but it's a hell of a lot
+    // easier to get provably correct than diffing the file against the contents of the KV store.
+    file_deleted(branch, file, function(err) {
+      if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
+
+      fs.readFile(fqf, {encoding:'utf8'}, function(err, body) {
+        /* istanbul ignore if */
+        if (err) return cb('Failed to read key ' + fqf + ' due to ' + err);
+        var body = body ? body.trim() : '';
+        try {
+          var obj = JSON.parse(body);
+          populate_kvs_from_json(branch, create_key_name(branch, file), obj, cb);
+        } catch(e) {
+          logger.warn("Failed to parse .json file.  Using body string as a KV.");
+          write_content_to_consul(create_key_name(branch, file), body, cb);
+        }
+      });
+    });
+  } else {
+    fs.readFile(fqf, {encoding:'utf8'}, function(err, body) {
+      /* istanbul ignore if */
+      if (err) return cb('Failed to read key ' + fqf + ' due to ' + err);
+      var body = body ? body.trim() : '';
+      write_content_to_consul(create_key_name(branch, file), body, cb);
+    });
+  }
 };
 
 /**
@@ -63,7 +130,8 @@ var file_deleted = function(branch, file, cb) {
 
   logger.trace('Deleting key %s', key_name);
 
-  consul.kv.del({'key': key_name, token: token}, function(err) {
+  // Delete this key.  Or, if mode is branch.expand_keys, delete all files underneath this key.
+  consul.kv.del({'key': key_name, token: token, recurse: branch.expand_keys}, function(err) {
     /* istanbul ignore if */
     if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
     cb();
@@ -200,3 +268,4 @@ exports.handleRefChange = function(branch, cb) {
     });
   });
 };
+

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -15,6 +15,7 @@ function Branch(repo_config, name) {
   Object.defineProperty(this, 'name', {value: name });
   Object.defineProperty(this, 'branch_parent', {value: repo_config.local_store + path.sep + repo_config.name});
   Object.defineProperty(this, 'branch_directory', {value: this.branch_parent + path.sep + name});
+  Object.defineProperty(this, 'expand_keys', { value: repo_config['mode'] === 'expand_keys' });
   Object.defineProperty(this, 'include_branch_name', {
     // If include_branch_name is not set, assume true.  Otherwise, identity check the value against true.
     value: repo_config['include_branch_name'] == undefined || repo_config['include_branch_name'] === true

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -15,7 +15,7 @@ function Branch(repo_config, name) {
   Object.defineProperty(this, 'name', {value: name });
   Object.defineProperty(this, 'branch_parent', {value: repo_config.local_store + path.sep + repo_config.name});
   Object.defineProperty(this, 'branch_directory', {value: this.branch_parent + path.sep + name});
-  Object.defineProperty(this, 'expand_keys', { value: repo_config['mode'] === 'expand_keys' });
+  Object.defineProperty(this, 'expand_keys', { value: repo_config['expand_keys'] === true });
   Object.defineProperty(this, 'include_branch_name', {
     // If include_branch_name is not set, assume true.  Otherwise, identity check the value against true.
     value: repo_config['include_branch_name'] == undefined || repo_config['include_branch_name'] === true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "email": "rbreen@cimpress.com"
     }
   ],
-  "repository" : {
+  "repository": {
     "type": "git",
     "url": "git://github.com/Cimpress-MCP/git2consul.git"
   },
@@ -16,11 +16,11 @@
     "body-parser": "~1.4.3",
     "bunyan": "1.1.3",
     "consul": "^0.10.0",
+    "coveralls": "^2.11.2",
     "express": "~4.6.1",
     "mkdirp": "0.5.0",
-    "coveralls": "^2.11.2",
     "rimraf": "2.2.8",
-    "underscore": "1.6.0"
+    "underscore": "^1.8.0"
   },
   "devDependencies": {
     "istanbul": "0.2.11",

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ If you would like git2consul to shutdown every time its configuration changes, y
 
 ###### expand_keys
 
-If you would like git2consul to treat JSON documents in your repo as fully formed subtrees, you can enable expand_keys mode via inclusion of the field `"expand_keys": true` at the top level the repo's configuration.  If this mode is enabled, git2consul will treat any valid JSON file (that is, any file with extension ".json" that parses to an object) as if it contains a subtree of Consul KVs.  For example, if you have the file `root.json` in repo `expando_keys` with the following contents:
+If you would like git2consul to treat JSON documents in your repo as fully formed subtrees, you can enable expand_keys mode via inclusion of the field `"expand_keys": true` at the top level of the repo's configuration.  If this mode is enabled, git2consul will treat any valid JSON file (that is, any file with extension ".json" that parses to an object) as if it contains a subtree of Consul KVs.  For example, if you have the file `root.json` in repo `expando_keys` with the following contents:
 
 ```javascript
 {
@@ -160,7 +160,7 @@ git2consul in expand_keys mode will generate the following KV:
 /expando_keys/root.json/first_level/second_level/third_level/you%20get%20the%20picture
 ```
 
-The value of that KV will be `right?`.
+The value in that KV pair will be `right?`.
 
 A few notes on how this behaves:
 
@@ -168,7 +168,7 @@ A few notes on how this behaves:
 
 * Expanded keys are URI-encoded.  The spaces in "you get the picture" are thus converted into `%20`.
 
-* Any non-JSON files, including files with the extension ".json" but that contain invalid JSON, are stored in your KV as if expand_keys mode was not enabled.
+* Any non-JSON files, including files with the extension ".json" that contain invalid JSON, are stored in your KV as if expand_keys mode was not enabled.
 
 ##### Clients
 

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -20,7 +20,7 @@ describe('Expand keys', function() {
 
     // Each of these tests needs a working repo instance, so create it here and expose it to the suite
     // namespace.  These are all tests of expand_keys mode, so set that here.
-    git_utils.initRepo(_.extend(git_utils.createRepoConfig(), {'mode': 'expand_keys'}), function(err, repo) {
+    git_utils.initRepo(_.extend(git_utils.createRepoConfig(), {'expand_keys': true}), function(err, repo) {
       if (err) return done(err);
 
       // The default repo created by initRepo has a single branch, master.
@@ -41,7 +41,7 @@ describe('Expand keys', function() {
       branch.handleRefChange(0, function(err) {
         if (err) return done(err);
         // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/simple/first_level/second_level', 'is_all_we_need', function(err, value) {
+        consul_utils.validateValue('test_repo/master/simple.json/first_level/second_level', 'is_all_we_need', function(err, value) {
           if (err) return done(err);
           done();
         });
@@ -60,7 +60,7 @@ describe('Expand keys', function() {
       branch.handleRefChange(0, function(err) {
         if (err) return done(err);
         // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/changeme/first_level', 'is_all_we_need', function(err, value) {
+        consul_utils.validateValue('test_repo/master/changeme.json/first_level', 'is_all_we_need', function(err, value) {
           if (err) return done(err);
 
           // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
@@ -71,7 +71,7 @@ describe('Expand keys', function() {
               if (err) return done(err);
 
               // At this point, the repo should have populated consul with our sample_key
-              consul_utils.validateValue('test_repo/master/changeme/first_level', 'is super different', function(err, value) {
+              consul_utils.validateValue('test_repo/master/changeme.json/first_level', 'is super different', function(err, value) {
                 if (err) return done(err);
 
                 done();
@@ -94,7 +94,7 @@ describe('Expand keys', function() {
       branch.handleRefChange(0, function(err) {
         if (err) return done(err);
         // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/busted', sample_value, function(err, value) {
+        consul_utils.validateValue('test_repo/master/busted.json', sample_value, function(err, value) {
           if (err) return done(err);
 
           // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
@@ -105,7 +105,7 @@ describe('Expand keys', function() {
               if (err) return done(err);
 
               // At this point, the repo should have populated consul with our sample_key
-              consul_utils.validateValue('test_repo/master/busted/not_busted', 'json', function(err, value) {
+              consul_utils.validateValue('test_repo/master/busted.json/not_busted', 'json', function(err, value) {
                 if (err) return done(err);
 
                 done();
@@ -138,7 +138,7 @@ describe('Expand keys', function() {
             if (err) return done(err);
 
             // At this point, the repo should have populated consul with our sample_key
-            consul_utils.validateValue('test_repo/master/happy/happy', 'json', function(err, value) {
+            consul_utils.validateValue('test_repo/master/happy.json/happy', 'json', function(err, value) {
               if (err) return done(err);
 
               // At this point, the repo should have populated consul with our sample_key
@@ -172,9 +172,9 @@ describe('Expand keys', function() {
       branch.handleRefChange(0, function(err) {
         if (err) return done(err);
         // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/special/fuzzy/second%20level', sample_value['fuzzy']['second level'], function(err, value) {
+        consul_utils.validateValue('test_repo/master/special.json/fuzzy/second%20level', sample_value['fuzzy']['second level'], function(err, value) {
           // At this point, the repo should have populated consul with our sample_key
-          consul_utils.validateValue('test_repo/master/special/fuzzy/second%2Flevel/ok%3F', sample_value['fuzzy']['second/level']['ok?'], function(err, value) {
+          consul_utils.validateValue('test_repo/master/special.json/fuzzy/second%2Flevel/ok%3F', sample_value['fuzzy']['second/level']['ok?'], function(err, value) {
             if (err) return done(err);
             done();
           });

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -32,7 +32,7 @@ describe('Expand keys', function() {
 
   it ('should handle additions of new JSON files', function(done) {
     var sample_key = 'simple.json';
-    var sample_value = '{ "first_level" : "is_all_we_need" }';
+    var sample_value = '{ "first_level" : { "second_level": "is_all_we_need" } }';
 
     // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
     git_utils.addFileToGitRepo(sample_key, sample_value, "Add a file.", function(err) {
@@ -41,7 +41,7 @@ describe('Expand keys', function() {
       branch.handleRefChange(0, function(err) {
         if (err) return done(err);
         // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/simple/first_level', 'is_all_we_need', function(err, value) {
+        consul_utils.validateValue('test_repo/master/simple/first_level/second_level', 'is_all_we_need', function(err, value) {
           if (err) return done(err);
           done();
         });

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -1,0 +1,52 @@
+var should = require('should');
+var _ = require('underscore');
+
+var mkdirp = require('mkdirp');
+
+// We want this above any git2consul module to make sure logging gets configured
+require('./git2consul_bootstrap_test.js');
+
+var repo = require('../lib/git/repo.js');
+var git_utils = require('./utils/git_utils.js');
+var consul_utils = require('./utils/consul_utils.js');
+
+var git_commands = require('../lib/git/commands.js');
+
+describe('Expand keys', function() {
+
+  // The current copy of the git master branch.  This is initialized before each test in the suite.
+  var branch;
+  beforeEach(function(done) {
+
+    // Each of these tests needs a working repo instance, so create it here and expose it to the suite
+    // namespace.  These are all tests of expand_keys mode, so set that here.
+    git_utils.initRepo(_.extend(git_utils.createRepoConfig(), {'mode': 'expand_keys'}), function(err, repo) {
+      if (err) return done(err);
+
+      // The default repo created by initRepo has a single branch, master.
+      branch = repo.branches['master'];
+
+      done();
+    });
+  });
+
+  it ('should handle additions of new JSON files', function(done) {
+    var sample_key = 'simple.json';
+    var sample_value = '{ "first_level" : "is_all_we_need" }';
+
+    // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
+    git_utils.addFileToGitRepo(sample_key, sample_value, "Add a file.", function(err) {
+      if (err) return done(err);
+
+      branch.handleRefChange(0, function(err) {
+        if (err) return done(err);
+        // At this point, the repo should have populated consul with our sample_key
+        consul_utils.validateValue('test_repo/master/simple/first_level', 'is_all_we_need', function(err, value) {
+          if (err) return done(err);
+          done();
+        });
+      });
+    });
+  });
+
+});

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -153,4 +153,33 @@ describe('Expand keys', function() {
       });
     });
   });
+
+  it ('should handle JSON files with special characters', function(done) {
+    var sample_key = 'special.json';
+    var sample_value = {
+      "fuzzy" : {
+        "second level": "ain\'t no one got time for that",
+        "second/level": {
+          "ok?": "yes"
+        }
+      }
+    };
+
+    // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
+    git_utils.addFileToGitRepo(sample_key, JSON.stringify(sample_value), "Add a file.", function(err) {
+      if (err) return done(err);
+
+      branch.handleRefChange(0, function(err) {
+        if (err) return done(err);
+        // At this point, the repo should have populated consul with our sample_key
+        consul_utils.validateValue('test_repo/master/special/fuzzy/second%20level', sample_value['fuzzy']['second level'], function(err, value) {
+          // At this point, the repo should have populated consul with our sample_key
+          consul_utils.validateValue('test_repo/master/special/fuzzy/second%2Flevel/ok%3F', sample_value['fuzzy']['second/level']['ok?'], function(err, value) {
+            if (err) return done(err);
+            done();
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -117,4 +117,40 @@ describe('Expand keys', function() {
     });
   });
 
+  it ('should handle JSON files comingled with non-JSON files', function(done) {
+    var json_key = 'happy.json';
+    var json_value = '{ "happy" : "json" }';
+    var sample_key = 'not_a_json_key';
+    var sample_value = 'password: calvin12345';
+
+    // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
+    git_utils.addFileToGitRepo(json_key, json_value, "Add a file.", function(err) {
+      if (err) return done(err);
+
+      branch.handleRefChange(0, function(err) {
+        if (err) return done(err);
+
+        // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
+        git_utils.addFileToGitRepo(sample_key, sample_value, "Add another file.", function(err) {
+          if (err) return done(err);
+
+          branch.handleRefChange(0, function(err) {
+            if (err) return done(err);
+
+            // At this point, the repo should have populated consul with our sample_key
+            consul_utils.validateValue('test_repo/master/happy/happy', 'json', function(err, value) {
+              if (err) return done(err);
+
+              // At this point, the repo should have populated consul with our sample_key
+              consul_utils.validateValue('test_repo/master/not_a_json_key', sample_value, function(err, value) {
+                if (err) return done(err);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fix GH-22.  Add an "expand_keys" mode for repos.  In this mode, any file ending with .json is expanded into an object and splatted out to a KV subtree at the prefix with that file name (excluding the .json extension).

This needs docs and probably more test cases (tests for special characters come to mind), but this is mergeable enough for discussion.

/cc: @benschw @maclennann @cleung2010 @chrisbaldauf @theopak 