### PR TITLE
Add Port and Secure option for consul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage
 reports
 node_modules
+.idea

--- a/lib/config_reader.js
+++ b/lib/config_reader.js
@@ -1,4 +1,4 @@
-var consul = require('consul')({'host': global.endpoint});
+var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure':global.secure});
 
 var _ = require('underscore');
 

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 
 var logger = require('../logging.js');
 
-var consul = require('consul')({'host': global.endpoint});
+var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure': global.secure});
 
 var token = undefined;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ for (var i=2; i<process.argv.length; ++i) {
 	}
     if(process.argv[i] === '-p' || process.argv[i] === '--port') {
       if(i+1 >= process.argv.length) {
-        logger.error("No endpoint provided with --port option");
+        logger.error("No port provided with --port option");
         process.exit(3);
       }
       global.port = process.argv[i+1];

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,10 @@ var os = require('os');
  */
 
 global.endpoint = "127.0.0.1";
-
+global.port = 8500
+global.secure = false
 for (var i=2; i<process.argv.length; ++i) {
+    if(process.argv[i] === '-s' || process.argv[i] === '--secure') global.secure = true
 	if(process.argv[i] === '-e' || process.argv[i] === '--endpoint') {
 		if(i+1 >= process.argv.length) {
 			logger.error("No endpoint provided with --endpoint option");
@@ -18,6 +20,13 @@ for (var i=2; i<process.argv.length; ++i) {
 		}
 		global.endpoint = process.argv[i+1];
 	}
+    if(process.argv[i] === '-p' || process.argv[i] === '--port') {
+      if(i+1 >= process.argv.length) {
+        logger.error("No endpoint provided with --port option");
+        process.exit(3);
+      }
+      global.port = process.argv[i+1];
+    }
 }
 
 var config_reader = require('./config_reader.js');


### PR DESCRIPTION
Adds --port and --secure flags to allow overriding the defaults. This lets us use TLS and non standard port for https communication.