### PR TITLE
Add a new config_seeder that accepts consul parameters + Fix documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,12 @@ Put that configuration in a file called `/tmp/git2consul.json`.  From the git2co
 node utils/config_seeder.js /tmp/git2consul.json
 ```
 
+If you need to specify custom arguments(endpoint, port, secure, etc), you can alternatively use `config_seeder_opts.js`.
+
+```
+node utils/config_seeder_opts.js -e 196.10.54.8 -p 8514 -s true -c path/to/config.json
+```
+
 Start git2consul:
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ Similarly to JSON, git2consul can also treat [Java .properties](http://docs.orac
 
 This is useful for teams willing to keep using legacy .properties files or don't want to use consul locally.
 
-Additionally, It has support for local variable :
+Additionally, it has support for local variable :
 
 ```
 bar=bar
@@ -200,10 +200,10 @@ Example, if you have a file `simple.properties` :
 git2consul will generate 
 
 ```
-/expand_keys/simple.json/foo
+/expand_keys/simple.json/bar
 ```
 
-returning `bar`
+returning `foo`
 
 You can combine .properties files with the [common_properties option](#common_properties-default-undefined), if you need a way to inject shared/common properties into other files.
 
@@ -291,7 +291,7 @@ and `simple.properties` :
 git2consul will generate 
            
 ```
-/expand_keys/simple.json/foo
+/expand_keys/simple.properties/foo
 ```
            
 returning `bar`.

--- a/utils/config_seeder_opts.js
+++ b/utils/config_seeder_opts.js
@@ -1,0 +1,71 @@
+var fs = require('fs');
+var _ = require('underscore');
+
+global.endpoint = "127.0.0.1";
+global.port = 8500;
+global.secure = false;
+global.config = "default_config.json";
+
+var parse_arguments = function() {
+  for (var i = 2; i < process.argv.length; ++i) {
+    if (process.argv[i] === '-s' || process.argv[i] === '--secure') global.secure = true;
+    if (process.argv[i] === '-e' || process.argv[i] === '--endpoint') {
+      if (i + 1 >= process.argv.length) {
+        logger.error("No endpoint provided with --endpoint option");
+        process.exit(3);
+      }
+      global.endpoint = process.argv[i + 1];
+    }
+    if (process.argv[i] === '-p' || process.argv[i] === '--port') {
+      if (i + 1 >= process.argv.length) {
+        logger.error("No port provided with --port option");
+        process.exit(3);
+      }
+      global.port = process.argv[i + 1];
+    }
+    if (process.argv[i] === '-c' || process.argv[i] === '--config') {
+      if (i + 1 >= process.argv.length) {
+        logger.error("No config file provided with --config option");
+        process.exit(3);
+      }
+      global.config = process.argv[i + 1];
+    }
+  }
+};
+
+var get_config_content = function() {
+  var config_file = global.config;
+
+  console.log('Adding %s as consul config', config_file);
+
+  var config_content = fs.readFileSync(config_file, {'encoding': 'utf8'});
+
+  try {
+    JSON.parse(config_content);
+  } catch (e) {
+    console.error('config_file is not valid JSON');
+    process.exit(1);
+  }
+  return config_content;
+};
+
+var push_config_to_consul = function(config_content) {
+  var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure': global.secure});
+
+  var params = {'key': 'git2consul/config', 'value': config_content};
+
+  console.log('Adding config %s : %s', params.key, params.value);
+
+  if (process.env.TOKEN) {
+    params = _.extend(params, {'token': process.env.TOKEN})
+  }
+
+  consul.kv.set(params, function(err) {
+    if (err) return console.error("Failed to write config: %s", err);
+  });
+};
+
+parse_arguments();
+var config_content = get_config_content();
+push_config_to_consul(config_content);
+

--- a/utils/default_config.json
+++ b/utils/default_config.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "repos" : [{
+    "name" : "sample_configuration",
+    "url" : "https://github.com/ryanbreen/git2consul_data.git",
+    "branches" : ["dev"],
+    "hooks": [{
+      "type" : "polling",
+      "interval" : "1"
+    }]
+  }]
+}


### PR DESCRIPTION
This PR try to fix the issue mentioned here https://github.com/Cimpress-MCP/git2consul/issues/28.

I decided to create a whole new seeder to prevent breaking backward compatibility with the previous version of git2consul.

I realised I made some mistakes in the documentation for this PR https://github.com/Cimpress-MCP/git2consul/pull/38.

Sorry about that, this PR fixes that as well.