### PR TITLE
Fix typo in .properties expansion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -212,7 +212,7 @@ Example, if you have a file `simple.properties` :
 git2consul will generate 
 
 ```
-/expand_keys/simple.json/bar
+/expand_keys/simple.properties/bar
 ```
 
 returning `foo`


### PR DESCRIPTION
As I understand it, it is a typo. If it is _not_ a typo, then there should be an explanation as to why the filename is mapped?