### PR TITLE
Fix common_properties feature. Update dependent .properties

### DIFF
--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -244,6 +244,15 @@ var process_records = function(branch, records, cb) {
       case 'A':
       case 'T':
         // Store added/modified file
+        if (record.path === branch.common_properties) {
+          branch.listAdditionalPropertyFiles(records, function(err, additionRecords) {
+            process_records(branch, additionRecords, function(errs) {
+              if (errs) {
+                return cb("Some consul updates failed:\n" + errs.join('\n'));
+              }
+            });
+          });
+        }
         ++pending_records;
         file_modified(branch, record.path, check_pending);
         break;

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -93,6 +93,10 @@ Branch.prototype.listAllFiles = function(cb) {
   git_commands.listAllFiles(this.branch_directory, cb);
 };
 
+Branch.prototype.listAdditionalPropertyFiles = function(modifiedRecord, cb) {
+  git_commands.listAdditionalPropertyFiles(modifiedRecord, this.branch_directory, cb);
+};
+
 Branch.prototype.getCurrentRef = function(cb) {
   git_commands.getCurrentRef(this.branch_directory, cb);
 };

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -93,8 +93,8 @@ Branch.prototype.listAllFiles = function(cb) {
   git_commands.listAllFiles(this.branch_directory, cb);
 };
 
-Branch.prototype.listAdditionalPropertyFiles = function(modifiedRecord, cb) {
-  git_commands.listAdditionalPropertyFiles(modifiedRecord, this.branch_directory, cb);
+Branch.prototype.listAdditionalPropertyFiles = function(modifiedRecords, cb) {
+  git_commands.listAdditionalPropertyFiles(modifiedRecords, this.branch_directory, cb);
 };
 
 Branch.prototype.getCurrentRef = function(cb) {

--- a/lib/git/commands.js
+++ b/lib/git/commands.js
@@ -118,6 +118,30 @@ exports.listAllFiles = function(cwd, cb) {
   });
 };
 
+exports.listAdditionalPropertyFiles = function(modifiedRecords, cwd, cb) {
+
+  function is_properties_not_modified(modifiedRecords, file) {
+    return file.substr(file.lastIndexOf('.') + 1) == "properties" && modifiedRecords.filter(function(record) {
+        return record.path == file;
+      }).length <= 0;
+  }
+
+  run_command('git ls-tree --name-status -r HEAD', cwd, function(err, output) {
+    /* istanbul ignore if */
+    if (err) return cb(err);
+
+    var records = [];
+    var files = output.split('\n');
+    files.forEach(function(file) {
+      if(is_properties_not_modified(modifiedRecords, file)) {
+        records.push({'type': 'M', 'path': file});
+      }
+    });
+
+    cb(null, records);
+  });
+};
+
 exports.getCurrentRef = function(cwd, cb) {
   run_command('git log -n 1 --pretty=format:"%H"', cwd, cb);
 };

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -347,6 +347,49 @@ describe('Expand keys with common properties', function() {
     });
   });
 
+
+  it('should update the dependent properties file if common is updated', function(done) {
+    var common_file = 'common.properties';
+    var common_kv = 'bar=bar';
+
+    var sample_file = 'simple.properties';
+    var sample_kv = 'foo=${bar}';
+
+    var updated_common_kv = 'bar=bar_updated';
+
+    git_utils.addFileToGitRepo(common_file, common_kv, "Add a file.", function(err) {
+      if (err) return done(err);
+
+      branch.handleRefChange(0, function(err) {
+
+        git_utils.addFileToGitRepo(sample_file, sample_kv, "Add a file.", function(err) {
+          if (err) return done(err);
+
+          branch.handleRefChange(0, function(err) {
+            if (err) return done(err);
+
+            consul_utils.validateValue('test_repo/master/simple.properties/foo', 'bar', function(err, value) {
+              if (err) return done(err);
+
+              git_utils.addFileToGitRepo(common_file, updated_common_kv, "Add a file.", function(err) {
+                if (err) return done(err);
+
+                branch.handleRefChange(0, function(err) {
+                  if (err) return done(err);
+
+                  consul_utils.validateValue('test_repo/master/simple.properties/foo', 'bar_updated', function(err, value) {
+                    if (err) return done(err);
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
 });
 
 describe('Expand keys with invalid common properties path ', function() {

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -202,42 +202,6 @@ describe('Expand keys', function() {
     });
   });
 
-  it ('should handle busted properties files', function(done) {
-    var sample_key = 'busted.properties';
-     //the parser is quite tolerant to syntax.
-     //the best way to test this case is by using an unset variable, which will throw an error when accessed.
-    var sample_value = 'foo=${bar}';
-
-    // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
-    git_utils.addFileToGitRepo(sample_key, sample_value, "Add a file.", function(err) {
-      if (err) return done(err);
-
-      branch.handleRefChange(0, function(err) {
-        if (err) return done(err);
-        // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/busted.properties', sample_value, function(err, value) {
-          if (err) return done(err);
-
-          // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
-          git_utils.addFileToGitRepo(sample_key, 'foo=bar', "Change a file.", function(err) {
-            if (err) return done(err);
-
-            branch.handleRefChange(0, function(err) {
-              if (err) return done(err);
-
-              // At this point, the repo should have populated consul with our sample_key
-              consul_utils.validateValue('test_repo/master/busted.properties/foo', 'bar', function(err, value) {
-                if (err) return done(err);
-
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
-  });
-
   /* common */
   it ('should handle different files commingled together', function(done) {
     var json_key = 'happy.json';
@@ -338,7 +302,7 @@ describe('Expand keys with common properties', function() {
     });
   });
 
-  it('should store as flat file if unset property', function(done) {
+  it('should store be tolerant if a property is unset', function(done) {
     var common_key = 'common.properties';
     var common_value = 'bar=bar';
     var sample_key = 'simple.properties';
@@ -355,7 +319,7 @@ describe('Expand keys with common properties', function() {
           branch.handleRefChange(0, function(err) {
             if (err) return done(err);
 
-            consul_utils.validateValue('test_repo/master/simple.properties', sample_value, function(err, value) {
+            consul_utils.validateValue('test_repo/master/simple.properties/foo', '${unset}', function(err, value) {
               if (err) return done(err);
               done();
             });
@@ -365,7 +329,7 @@ describe('Expand keys with common properties', function() {
     });
   });
 
-  it('should store as flat file if common properties file is invalid / not found', function(done) {
+  it('should be tolerant if common properties file is invalid / not found', function(done) {
     var sample_key = 'simple.properties';
     var sample_value = 'foo=${unset}';
 
@@ -375,7 +339,7 @@ describe('Expand keys with common properties', function() {
           branch.handleRefChange(0, function(err) {
             if (err) return done(err);
 
-            consul_utils.validateValue('test_repo/master/simple.properties', sample_value, function(err, value) {
+            consul_utils.validateValue('test_repo/master/simple.properties/foo', '${unset}', function(err, value) {
               if (err) return done(err);
               done();
             });
@@ -403,7 +367,7 @@ describe('Expand keys with invalid common properties path ', function() {
     });
   });
 
-  it('should store as flat file if invalid path in config', function(done) {
+  it('should be tolerant if invalid path in config', function(done) {
     var common_key = 'common.properties';
     var common_value = 'bar=bar';
     var sample_key = 'simple.properties';
@@ -420,7 +384,7 @@ describe('Expand keys with invalid common properties path ', function() {
           branch.handleRefChange(0, function(err) {
             if (err) return done(err);
 
-            consul_utils.validateValue('test_repo/master/simple.properties', sample_value, function(err, value) {
+            consul_utils.validateValue('test_repo/master/simple.properties/foo', '${bar}', function(err, value) {
               if (err) return done(err);
               done();
             });

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -202,6 +202,42 @@ describe('Expand keys', function() {
     });
   });
 
+  it ('should handle busted properties files', function(done) {
+    var sample_key = 'busted.properties';
+     //the parser is quite tolerant to syntax.
+     //the best way to test this case is by using an unset variable, which will throw an error when accessed.
+    var sample_value = 'foo=${bar}';
+
+    // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
+    git_utils.addFileToGitRepo(sample_key, sample_value, "Add a file.", function(err) {
+      if (err) return done(err);
+
+      branch.handleRefChange(0, function(err) {
+        if (err) return done(err);
+        // At this point, the repo should have populated consul with our sample_key
+        consul_utils.validateValue('test_repo/master/busted.properties', sample_value, function(err, value) {
+          if (err) return done(err);
+
+          // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.
+          git_utils.addFileToGitRepo(sample_key, 'foo=bar', "Change a file.", function(err) {
+            if (err) return done(err);
+
+            branch.handleRefChange(0, function(err) {
+              if (err) return done(err);
+
+              // At this point, the repo should have populated consul with our sample_key
+              consul_utils.validateValue('test_repo/master/busted.properties/foo', 'bar', function(err, value) {
+                if (err) return done(err);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   /* common */
   it ('should handle different files commingled together', function(done) {
     var json_key = 'happy.json';
@@ -302,7 +338,7 @@ describe('Expand keys with common properties', function() {
     });
   });
 
-  it('should store be tolerant if a property is unset', function(done) {
+  it('should store as flat file if unset property', function(done) {
     var common_key = 'common.properties';
     var common_value = 'bar=bar';
     var sample_key = 'simple.properties';
@@ -319,7 +355,7 @@ describe('Expand keys with common properties', function() {
           branch.handleRefChange(0, function(err) {
             if (err) return done(err);
 
-            consul_utils.validateValue('test_repo/master/simple.properties/foo', '${unset}', function(err, value) {
+            consul_utils.validateValue('test_repo/master/simple.properties', sample_value, function(err, value) {
               if (err) return done(err);
               done();
             });
@@ -329,7 +365,7 @@ describe('Expand keys with common properties', function() {
     });
   });
 
-  it('should be tolerant if common properties file is invalid / not found', function(done) {
+  it('should store as flat file if common properties file is invalid / not found', function(done) {
     var sample_key = 'simple.properties';
     var sample_value = 'foo=${unset}';
 
@@ -339,7 +375,7 @@ describe('Expand keys with common properties', function() {
           branch.handleRefChange(0, function(err) {
             if (err) return done(err);
 
-            consul_utils.validateValue('test_repo/master/simple.properties/foo', '${unset}', function(err, value) {
+            consul_utils.validateValue('test_repo/master/simple.properties', sample_value, function(err, value) {
               if (err) return done(err);
               done();
             });
@@ -410,7 +446,7 @@ describe('Expand keys with invalid common properties path ', function() {
     });
   });
 
-  it('should be tolerant if invalid path in config', function(done) {
+  it('should store as flat file if invalid path in config', function(done) {
     var common_key = 'common.properties';
     var common_value = 'bar=bar';
     var sample_key = 'simple.properties';
@@ -427,7 +463,7 @@ describe('Expand keys with invalid common properties path ', function() {
           branch.handleRefChange(0, function(err) {
             if (err) return done(err);
 
-            consul_utils.validateValue('test_repo/master/simple.properties/foo', '${bar}', function(err, value) {
+            consul_utils.validateValue('test_repo/master/simple.properties', sample_value, function(err, value) {
               if (err) return done(err);
               done();
             });


### PR DESCRIPTION
When a user change a properties in the common.properties file, we expect this change to be mirrored in consul. 

This doesn't work because we only update k/v of changed file. I changed that behavior to update all .properties file when the common.properties file is changed. 

Fixing my own bugs here, sorry :P