### PR TITLE
Fixed error reporting on startup. 

### DIFF
--- a/lib/git/index.js
+++ b/lib/git/index.js
@@ -70,8 +70,7 @@ exports.createRepos = function(config, cb) {
 
   var error_handler = function(err) {
     // Report the error to cb but also gracefully shutdown.
-    exports.gracefulShutdown();
-    cb(err);
+    exports.gracefulShutdown(cb(err));
   };
 
   // Validate that local_store exists.


### PR DESCRIPTION
Without this change, an error during startup will lead to gracefulShutdown being called, then process.exit before logging the error.
The specific error I was not seeing was "Failed to create repos due to Error: mountpoint must not start or end with /."