### PR TITLE
Fix invalid reference `error` with correct reference `err`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ for (var i=2; i<process.argv.length; ++i) {
 if (global.config_file) {
   config_seeder.set(global.config_key, global.config_file, function(err) {
     if (err) {
-      logger.error(error)
+      logger.error(err)
       process.exit(2)
     };
   });


### PR DESCRIPTION
This is blowing up at runtime for me without the fix.