### PR TITLE
Make regex more flexible for support_tags feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ usage example :
 }
 ```
 
+This feature will only work with **annotated tags**. `man git-tag` for more information about annotated tags
+
 ##### common_properties (default: undefined)
 
 a `common_properties` is a repo-level option instructing git2consul to inject common/shared properties as variables into other .properties files.

--- a/lib/git/commands.js
+++ b/lib/git/commands.js
@@ -64,7 +64,7 @@ exports.extractTags = function (repo_url, cwd, cb) {
   run_command('git ls-remote --tags' + ' ' + repo_url, cwd, function (err, output) {
     var extracted_tags = [];
     var one_tag;
-    var tag_regex = /refs\/tags\/([a-z0-9]*)\^\{\}/ig;
+    var tag_regex = /refs\/tags\/(.*)\^\{\}/ig;
     while ((one_tag = tag_regex.exec(output)) !== null) {
       extracted_tags.push(one_tag[1]);
     }

--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -45,7 +45,7 @@ exports.init = function(config, repo) {
         start_delayed_updater(new_tags[i])
       }
     });
-    setInterval(pollForNewTags, testing ? 10 : /* istanbul ignore next */
+    setInterval(pollForNewTags, testing ? 1000 : /* istanbul ignore next */
     config.interval * 60 * 1000);
   };
 

--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -38,23 +38,23 @@ exports.init = function(config, repo) {
       ((Math.floor((Math.random() * 30) + 1) ) * 1000)); // In the common case, start polling a random number of seconds later.
   };
 
-  var pollForNewTags = function () {
+  function pull_new_tags() {
     repo.createNewTagsAsBranch(function(err, new_tags) {
       if (err) return logger.error(err);
       for (var i = 0; i < new_tags.length; i++) {
         start_delayed_updater(new_tags[i])
       }
     });
-    setInterval(pollForNewTags, testing ? 1000 : /* istanbul ignore next */
-    config.interval * 60 * 1000);
-  };
+  }
 
   repo.branch_names.forEach(function (branch_name) {
     start_delayed_updater(branch_name)
   });
 
   if (repo.repo_config.support_tags === true) {
-    pollForNewTags();
+    pull_new_tags();
+    setInterval(pull_new_tags, testing ? 1000 : /* istanbul ignore next */
+    config.interval * 60 * 1000);
   }
 
   logger.debug('Polling hook initialized with %s minute intervals', config.interval);

--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -30,10 +30,11 @@ exports.init = function(config, repo) {
 
   // Start the branch updater some random number of seconds from 1 to 30.  This is just to space
   // out the updates and reduce load spikes against git servers.
-  var start_delayed_updater = function(branch_name) {
-    var branch = repo.branches[branch_name];
+  var start_delayed_updater = function() {
     setTimeout(function() {
-      start_branch_updater(branch);
+      for(var branch_name in repo.branches) {
+        start_branch_updater(repo.branches[branch_name])
+      }
     }, testing ? 10 : /* istanbul ignore next */
       ((Math.floor((Math.random() * 30) + 1) ) * 1000)); // In the common case, start polling a random number of seconds later.
   };
@@ -45,13 +46,11 @@ exports.init = function(config, repo) {
     config.interval * 60 * 1000);
   };
 
-  repo.branch_names.forEach(function (branch_name) {
-    start_delayed_updater(branch_name)
-  });
-
   if (repo.repo_config.support_tags === true) {
     pollForNewTags();
   }
+
+  start_delayed_updater();
 
   logger.debug('Polling hook initialized with %s minute intervals', config.interval);
 };

--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -30,11 +30,10 @@ exports.init = function(config, repo) {
 
   // Start the branch updater some random number of seconds from 1 to 30.  This is just to space
   // out the updates and reduce load spikes against git servers.
-  var start_delayed_updater = function() {
+  var start_delayed_updater = function(branch_name) {
+    var branch = repo.branches[branch_name];
     setTimeout(function() {
-      for(var branch_name in repo.branches) {
-        start_branch_updater(repo.branches[branch_name])
-      }
+      start_branch_updater(branch);
     }, testing ? 10 : /* istanbul ignore next */
       ((Math.floor((Math.random() * 30) + 1) ) * 1000)); // In the common case, start polling a random number of seconds later.
   };
@@ -50,11 +49,13 @@ exports.init = function(config, repo) {
     config.interval * 60 * 1000);
   };
 
+  repo.branch_names.forEach(function (branch_name) {
+    start_delayed_updater(branch_name)
+  });
+
   if (repo.repo_config.support_tags === true) {
     pollForNewTags();
   }
-
-  start_delayed_updater();
 
   logger.debug('Polling hook initialized with %s minute intervals', config.interval);
 };

--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -40,9 +40,13 @@ exports.init = function(config, repo) {
   };
 
   var pollForNewTags = function () {
-    setInterval(function () {
-      repo.createNewTagsAsBranch();
-    }, testing ? 10 : /* istanbul ignore next */
+    repo.createNewTagsAsBranch(function(err, new_tags) {
+      if (err) return logger.error(err);
+      for (var i = 0; i < new_tags.length; i++) {
+        start_delayed_updater(new_tags[i])
+      }
+    });
+    setInterval(pollForNewTags, testing ? 10 : /* istanbul ignore next */
     config.interval * 60 * 1000);
   };
 

--- a/lib/git/hooks/webhook.js
+++ b/lib/git/hooks/webhook.js
@@ -93,7 +93,9 @@ function create_webhook(config, repo, implementation) {
         if (changes.length === 0) {
           logger.trace('No changes in a relevant branch. Checking and updating tags');
           if (repo.repo_config.support_tags === true) {
-            repo.createNewTagsAsBranch();
+            repo.createNewTagsAsBranch(function(err, new_tags) {
+              if (err) return logger.error(err);
+            });
           }
           return res.send('ok');
         }

--- a/lib/git/index.js
+++ b/lib/git/index.js
@@ -113,10 +113,6 @@ exports.createRepos = function(config, cb) {
             return error_handler("Failed to load repo " + repo_config.name + " due to " + err);
           }
 
-          if (repo_config.support_tags == true) {
-            exports.repos[repo_config.name].createNewTagsAsBranch();
-          }
-
           logger.info("Loaded repo %s", repo_config.name);
           cb();
         });

--- a/lib/git/repo.js
+++ b/lib/git/repo.js
@@ -81,11 +81,11 @@ Repo.prototype.addBranch = function(branch) {
   });
 };
 
-Repo.prototype.createNewTagsAsBranch = function() {
+Repo.prototype.createNewTagsAsBranch = function(cb) {
   var this_obj = this;
   git_commands.extractTags(this_obj.url, this_obj.repo_config.local_store, function (err, tags) {
     /* istanbul ignore if */
-    if (err) return logger.error(err);
+    if (err) return cb(err);
 
     var new_tags = tags.filter(function (tag) {
       return this_obj.branch_names.indexOf(tag) < 0
@@ -95,6 +95,7 @@ Repo.prototype.createNewTagsAsBranch = function() {
       var branch = new Branch(this_obj.repo_config, tag_name);
       this_obj.addBranch(branch);
     });
+    cb(null, new_tags);
   });
 };
 

--- a/test/git2consul_webhook_and_polling_test.js
+++ b/test/git2consul_webhook_and_polling_test.js
@@ -272,7 +272,7 @@ describe('webhook with support_tags', function() {
 
       request(req_conf, function (err) {
         setTimeout(function () {
-          var version = "v1";
+          var version = "v1.5_7";
           config.body = {ref: "refs/tag/" + version, head_commit: {id: 12345}};
           var req_conf_for_tag = extractReqInfo(config);
           create_tag_and_check_consul(version, 'test_repo', sample_key, cb);


### PR DESCRIPTION
The regex needs to be a bit more greedy to accept special characters like dots or underscores.

Currently, the feature is broken if someone pushes a tag with such characters.

After further testing, I also noticed the feature doesn't work with lightweight tags. Git2Consul clones all branches/tags in separate repository with `git clone -b <branch/tag>`, this command doesn't work with lightweight tags. 

Reading through the git documentation I noticed that
`Annotated tags are meant for release while lightweight tags are meant for private or temporary object labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight tags by default.` And I suspect this is the reason it doesn't work. Therefore, I added a note in the documentation about using annotated tags.

Last fix, we now make sure to periodically check the references for every branches *and* tags. This is useful in case a user deletes a tag reference directly in consul, it gets sync back automatically. 