### PR TITLE
Allow git2consul global package installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 reports
 node_modules
 .idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.12.11
+
+* Allow git2consul global package installation with `npm install -g git2consul`.
+
 v0.12.10
 
 * Ensure that config_reader.read() runs after config_seeder.set() [GH-69]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ git2consul takes one or many git repositories and mirrors them into [Consul](htt
 
 #### Installation
 
-`npm install git2consul`
+`npm install -g git2consul`
 
 #### Mailing List
 
@@ -50,13 +50,13 @@ EOF
 Start git2consul:
 
 ```
-node . --config-file /tmp/git2consul.json
+git2consul --config-file /tmp/git2consul.json
 ```
 
 or for remote Consul endpoint:
 
 ```
-node . --endpoint remote.consul.host --port 80 --config-file /tmp/git2consul.json
+git2consul --endpoint remote.consul.host --port 80 --config-file /tmp/git2consul.json
 ```
 
 git2consul will now poll the "dev" branch of the "git2consul_data.git" repo once per minute.  On first run, it will mirror the 3 files into your Consul K/V with keys:
@@ -154,7 +154,7 @@ There are environment variable equivalents for the parameters that git2consul ac
 By default, git2consul looks for its configuration at the Consul Key `git2consul/config`.  You can override this with a `-c` of `--config_key` command line switch, like so:
 
 ```sh
-node . -c git2consul/alternative_config
+git2consul -c git2consul/alternative_config
 ```
 
 ##### No Daemon

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var util = require('util');
 
 var git2consul = require('./lib');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "should": "3.3.2",
     "xunit-file": "0.0.5"
   },
+  "preferGlobal": true,
+  "bin": "./index.js",
   "scripts": {
     "test": "./node_modules/.bin/_mocha --reporter spec -t 10000 test | bunyan",
     "cov": "`npm bin`/istanbul cover --root . -x node_modules -x test --dir ./reports `npm bin`/_mocha -- --reporter spec -t 10000 test | bunyan",


### PR DESCRIPTION
Allow you to install git2consul globally and have the `git2consul` executable in path.

```sh
npm install -g git2consul
git2consul
```