### PR TITLE
Added include_file_name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ git2consul expects to be run on the same node as a Consul agent.  git2consul exp
     }]
   },{
     "name" : "github_data",
-    "mode" : "expand_keys",
+    "expand_keys": true,
     "url" : "git@github.com:ryanbreen/git2consul_data.git",
     "branches" : [ "master" ],
     "hooks": [{
@@ -235,6 +235,11 @@ You can combine .properties files with the [common_properties option](#common_pr
 ##### include_branch_name (default: true)
 
 `include_branch_name` is a repo-level option instructing git2consul to use the branch name as part of the key prefix.  Setting this option to false will omit the branch name.
+
+
+##### include_file_name (default: true)
+
+`include_file_name` is a repo-level option instructing git2consul to use the file name as part of the key prefix. Setting this option to false will omit the file name.
 
 ##### mountpoint (default: undefined)
 

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -47,7 +47,11 @@ var create_key_name = function(branch, file, ref) {
   if (branch.source_root && !ref) {
     file = file.substring(branch.source_root.length + 1);
   }
-  key_parts.push(file);
+  if (branch.include_file_name) {
+    key_parts.push(file);
+  } else {
+    key_parts.push(file.substr(0, file.lastIndexOf('/')));
+  }
   return key_parts.join('/');
 };
 

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -21,6 +21,10 @@ function Branch(repo_config, name) {
     // If include_branch_name is not set, assume true.  Otherwise, identity check the value against true.
     value: repo_config['include_branch_name'] == undefined || repo_config['include_branch_name'] === true
   });
+  Object.defineProperty(this, 'include_file_name', {
+    // If include_file_name is not set, assume true.  Otherwise, identity check the value against true.
+    value: repo_config['include_file_name'] == undefined || repo_config['include_file_name'] === true
+  });
   Object.defineProperty(this, 'mountpoint', {value: repo_config['mountpoint'] });
 
   if (repo_config['source_root'] &&


### PR DESCRIPTION
Added `include_file_name` option to include or not the filename in the consul key prefix, behaving much like `include_branch_name`