### PR TITLE
Add expand_keys type support for yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ git2consul expects to be run on the same node as a Consul agent.  git2consul exp
     }]
   },{
     "name" : "github_data",
-    "mode" : "expand_keys",
+    "expand_keys" : true,
     "url" : "git@github.com:ryanbreen/git2consul_data.git",
     "branches" : [ "master" ],
     "hooks": [{
@@ -202,6 +202,30 @@ A few notes on how this behaves:
 * Expanded keys are URI-encoded.  The spaces in "you get the picture" are thus converted into `%20`.
 
 * Any non-JSON files, including files with the extension ".json" that contain invalid JSON, are stored in your KV as if expand_keys mode was not enabled.
+
+###### YAML
+
+Similarly to JSON, git2consul can treat YAML documents in your repo as fully formed subtrees.
+
+```yaml
+---
+# file: example.yaml or example.yml
+first_level:
+  second_level:
+    third_level:
+      my_key: my_value
+```
+
+git2consul in expand_keys mode will generate the following KV:
+
+```
+/expando_keys/example.yaml/first_level/second_level/third_level/my_key
+or
+/expando_keys/example.yml/first_level/second_level/third_level/my_key
+```
+
+The value in that KV pair will be `my_value`.
+
 
 ###### .properties
 

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -2,7 +2,6 @@ var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
 var yaml = require('js-yaml');
-var eachAsync = require('each-async');
 var utils = require('../utils.js');
 
 var logger = require('../logging.js');
@@ -118,7 +117,6 @@ var file_modified = function(branch, file, cb) {
   };
 
   var handle_properties_kv_file = function(file_path, common_properties_relative_path, cb) {
-
     function extract_and_populate_properties(file_body, common_body, cb) {
       utils.load_properties(file_body, common_body, function (error, obj) {
         if (error) {
@@ -155,17 +153,11 @@ var file_modified = function(branch, file, cb) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
       body ? body.trim() : '';
-      var docs = [];
       try {
-        yaml.loadAll(body, function(doc) {
-          docs.push(doc);
-        });
-
-        eachAsync(docs, function(doc,index,cb) {
-          populate_kvs_from_object(branch, create_key_name(branch, file), doc, cb);
-        }, cb);
+        var obj = yaml.safeLoad(body);
+        populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
       } catch (e) {
-        logger.warn("Failed to parse .yaml file " + file + ".  Using body string as a KV.",e);
+        logger.warn("Failed to parse .yaml file " + file + ".  Using body string as a KV.");
         write_content_to_consul(create_key_name(branch, file), body, cb);
       }
     });
@@ -188,15 +180,15 @@ var file_modified = function(branch, file, cb) {
         if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
         handle_json_kv_file(fqf, cb);
       });
+    } else if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      file_deleted(branch, file, function (err) {
+        if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
+        handle_yaml_kv_file(fqf, cb);
+      });
     } else if (file.endsWith('.properties')) {
       file_deleted(branch, file, function (err) {
         if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
         handle_properties_kv_file(fqf, branch.common_properties, cb);
-      });
-    } else if (file.endsWith('.yaml') || file.endsWith('.yml')) {
-      file_deleted(branch, file, function (err) {
-        if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
-        handle_yaml_kv_file(fqf, branch.common_properties, cb);
       });
     } else {
       handle_as_flat_file(fqf, branch, file, cb);

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -1,6 +1,8 @@
 var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
+var yaml = require('js-yaml');
+var eachAsync = require('each-async');
 var utils = require('../utils.js');
 
 var logger = require('../logging.js');
@@ -104,7 +106,7 @@ var file_modified = function(branch, file, cb) {
       fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
         /* istanbul ignore if */
         if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
-        var body = body ? body.trim() : '';
+        body ? body.trim() : '';
         try {
           var obj = JSON.parse(body);
           populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
@@ -148,11 +150,32 @@ var file_modified = function(branch, file, cb) {
     });
   };
 
+  var handle_yaml_kv_file = function(file_path, cb) {
+    fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
+      /* istanbul ignore if */
+      if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
+      body ? body.trim() : '';
+      var docs = [];
+      try {
+        yaml.loadAll(body, function(doc) {
+          docs.push(doc);
+        });
+
+        eachAsync(docs, function(doc,index,cb) {
+          populate_kvs_from_object(branch, create_key_name(branch, file), doc, cb);
+        }, cb);
+      } catch (e) {
+        logger.warn("Failed to parse .yaml file " + file + ".  Using body string as a KV.",e);
+        write_content_to_consul(create_key_name(branch, file), body, cb);
+      }
+    });
+  };
+
   var handle_as_flat_file = function(fqf, branch, file, cb) {
     fs.readFile(fqf, {encoding: 'utf8'}, function (err, body) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + fqf + ' due to ' + err);
-      var body = body ? body.trim() : '';
+      body ? body.trim() : '';
       write_content_to_consul(create_key_name(branch, file), body, cb);
     });
   };
@@ -169,6 +192,11 @@ var file_modified = function(branch, file, cb) {
       file_deleted(branch, file, function (err) {
         if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
         handle_properties_kv_file(fqf, branch.common_properties, cb);
+      });
+    } else if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      file_deleted(branch, file, function (err) {
+        if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
+        handle_yaml_kv_file(fqf, branch.common_properties, cb);
       });
     } else {
       handle_as_flat_file(fqf, branch, file, cb);

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -105,7 +105,7 @@ var file_modified = function(branch, file, cb) {
       fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
         /* istanbul ignore if */
         if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
-        body ? body.trim() : '';
+        body = body ? body.trim() : '';
         try {
           var obj = JSON.parse(body);
           populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
@@ -152,7 +152,7 @@ var file_modified = function(branch, file, cb) {
     fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
-      body ? body.trim() : '';
+      body = body ? body.trim() : '';
       try {
         var obj = yaml.safeLoad(body);
         populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
@@ -167,7 +167,7 @@ var file_modified = function(branch, file, cb) {
     fs.readFile(fqf, {encoding: 'utf8'}, function (err, body) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + fqf + ' due to ' + err);
-      body ? body.trim() : '';
+      body = body ? body.trim() : '';
       write_content_to_consul(create_key_name(branch, file), body, cb);
     });
   };

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "rimraf": "2.2.8",
     "underscore": "^1.8.0",
     "properties": "1.2.1",
-    "js-yaml": "^3.6.1",
-    "each-async": "^1.1.1"
+    "js-yaml": "^3.6.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "mkdirp": "0.5.0",
     "rimraf": "2.2.8",
     "underscore": "^1.8.0",
-    "properties": "1.2.1"
+    "properties": "1.2.1",
+    "js-yaml": "^3.6.1",
+    "each-async": "^1.1.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/git2consul_expand_keys_test.js
+++ b/test/git2consul_expand_keys_test.js
@@ -214,7 +214,7 @@ describe('Expand keys', function() {
       branch.handleRefChange(0, function(err) {
         if (err) return done(err);
         // At this point, the repo should have populated consul with our sample_key
-        consul_utils.validateValue('test_repo/master/busted.yaml', sample_value, function(err, value) {
+        consul_utils.validateValue('test_repo/master/busted.yaml', "---\n\ntest: key: value", function(err, value) {
           if (err) return done(err);
 
           // Add the file, call branch.handleRef to sync the commit, then validate that consul contains the correct info.


### PR DESCRIPTION
Implements #54.

Based on https://github.com/Cimpress-MCP/git2consul/pull/87 plus test cases comparable to the JSON key expansion, a few bug fixes (including a serious one that I had already observed while testing with my real data), and updates to the README.