### PR TITLE
Improve logging by including repo names.

### DIFF
--- a/lib/git/hooks/polling.js
+++ b/lib/git/hooks/polling.js
@@ -22,7 +22,7 @@ exports.init = function(config, repo) {
       branch.handleRefChange(null, function(err) {
         /* istanbul ignore next */
         if (err) logger.error(err);
-        logger.debug('Updates in branch %s complete', branch.name);
+        logger.debug('Updates in branch %s of repo %s complete', branch.name, repo.name);
       });
     }, testing ? 1000 /* istanbul ignore next */ :
       config.interval * 60 * 1000);

--- a/lib/git/hooks/webhook.js
+++ b/lib/git/hooks/webhook.js
@@ -103,7 +103,7 @@ function create_webhook(config, repo, implementation) {
         for (var i=0; i<changes.length; ++i) {
           var change = changes[i];
           var to_hash = change.to_hash;
-          logger.info('Webhook noted change to branch %s with commit id %s', change.branch, change.to_hash);
+          logger.info('Webhook noted change to branch %s of repo %s with commit id %s', change.branch, repo.name, change.to_hash);
 
           // Update consul git branch
           var branch = repo.branches[change.branch];
@@ -112,7 +112,7 @@ function create_webhook(config, repo, implementation) {
               /* istanbul ignore next */
               if (err) logger.error(err);
 
-              logger.debug('Updates in branch %s complete', change.branch);
+              logger.debug('Updates in branch %s of repo %s complete', change.branch, repo.name);
             });
           }
         }


### PR DESCRIPTION
When using multiple repos it's very helpful for the logs to name the
repo and not just the branch.  Fix some cases where only the branch
name is logged to also log the the repo names.
