### PR TITLE
Added missing definition of logger to config_seeder util.

### DIFF
--- a/utils/config_seeder.js
+++ b/utils/config_seeder.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var config_seeder = require('../lib/config_seeder.js')
+var logger = require('../lib/logging.js');
 
 /**
  * First, check if there is a command line override for the consul endpoint.


### PR DESCRIPTION
When I ran this without consul running, it tried to write an error, but it failed to dereference "logger" variable.