### PR TITLE
Only ignore embedded JSON/YAML/properties file extensions

### DIFF
--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -63,7 +63,7 @@ var create_key_name = function(branch, file, ref) {
   }
 
   // Remove extension from the key name when expanding an embedded document.
-  if (branch.ignore_file_extension && (branch.expand_keys || branch.expand_keys_diff)) {
+  if (branch.ignore_file_extension && branch.expand_keys) {
     var extension = file.substr(file.lastIndexOf('.') + 1);
     if (_.contains(EXPAND_EXTENSIONS, extension)) {
       file = file.substr(0, file.lastIndexOf('.'));

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -10,6 +10,8 @@ var consul = require('consul')({'host': global.endpoint, 'port': global.port, 's
 
 var token = undefined;
 
+const EXPAND_EXTENSIONS = ['json', 'yaml', 'yml', 'properties'];
+
 // This makes life a bit easier for expand_keys mode, allowing us to check for a .json
 // extension with less code per line.
 String.prototype.endsWith = function(suffix) {
@@ -60,9 +62,12 @@ var create_key_name = function(branch, file, ref) {
     file = file.substring(branch.source_root.length + 1);
   }
 
-  // Ignore file extensoion on demand
-  if (branch.ignore_file_extension) {
-    file = file.substr(0, file.lastIndexOf("."));
+  // Remove extension from the key name when expanding an embedded document.
+  if (branch.ignore_file_extension && (branch.expand_keys || branch.expand_keys_diff)) {
+    var extension = file.substr(file.lastIndexOf('.') + 1);
+    if (_.contains(EXPAND_EXTENSIONS, extension)) {
+      file = file.substr(0, file.lastIndexOf('.'));
+    }
   }
   key_parts.push(file);
   return key_parts.join('/');

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -62,4 +62,29 @@ describe('ignore_file_extension', function() {
     });
   });
 
+  it ('should not ignore file extension when expand_keys == false', function(done) {
+
+    git_commands.init(git_utils.TEST_REMOTE_REPO, function(err) {
+      if (err) return done(err);
+
+      mkdirp(git_utils.TEST_REMOTE_REPO + 'ignore_file_extension', function(cb) {
+        if (err) return done(err);
+
+        git_utils.addFileToGitRepo('ignore_file_extension/user-service-dev.properties', "default.connection.pool.db.url=jdbc:mysql://db-host:3306/user", "User property file for dev environment added.", function(err) {
+          if (err) return done(err);
+
+          var repo = new Repo(repo_config);
+
+          repo.init(function(err) {
+            if (err) return done(err);
+            consul_utils.validateValue('test_repo/master/ignore_file_extension/user-service-dev.properties', 'default.connection.pool.db.url=jdbc:mysql://db-host:3306/user', function(err, value) {
+              if (err) return done(err);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
 });

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -25,14 +25,6 @@ describe('ignore_file_extension', function() {
     done();
   });
 
-  // Tear down Consul KV values after tests.
-  afterEach(function(done) {
-    consul_utils.purgeKeys('test_repo/master/ignore_file_extension', function(err) {
-      if (err) return done(err);
-    });
-    done();
-  });
-
   var test_files_known_extensions = {
     'ignore_file_extension/config_yaml.yaml': 'foo: bar',
     'ignore_file_extension/config_yml.yml': 'foo: bar',

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -21,8 +21,15 @@ describe('ignore_file_extension', function() {
   var repo_config;
   beforeEach(function(done) {
     repo_config = git_utils.createRepoConfig();
-    repo_config.source_root = "src/main/resources";
     repo_config.ignore_file_extension = true;
+    done();
+  });
+
+  // Tear down Consul KV values after tests.
+  afterEach(function(done) {
+    consul_utils.purgeKeys('test_repo/master/ignore_file_extension', function(err) {
+      if (err) return done(err);
+    });
     done();
   });
 
@@ -33,10 +40,10 @@ describe('ignore_file_extension', function() {
     git_commands.init(git_utils.TEST_REMOTE_REPO, function(err) {
       if (err) return done(err);
 
-      mkdirp(git_utils.TEST_REMOTE_REPO + "src/main/resources", function(cb) {
+      mkdirp(git_utils.TEST_REMOTE_REPO + 'ignore_file_extension', function(cb) {
         if (err) return done(err);
 
-        git_utils.addFileToGitRepo("src/main/resources/user-service-dev.properties", "default.connection.pool.db.url=jdbc:mysql://db-host:3306/user", "User property file for dev environment added.", function(err) {
+        git_utils.addFileToGitRepo("ignore_file_extension/user-service-dev.properties", "default.connection.pool.db.url=jdbc:mysql://db-host:3306/user", "User property file for dev environment added.", function(err) {
           if (err) return done(err);
 
           repo_config.expand_keys = true;
@@ -44,7 +51,7 @@ describe('ignore_file_extension', function() {
 
           repo.init(function(err) {
             if (err) return done(err);
-            consul_utils.validateValue('test_repo/master/user-service-dev/default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
+            consul_utils.validateValue('test_repo/master/ignore_file_extension/user-service-dev/default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {
               if (err) return done(err);
               done();
             });

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -35,8 +35,9 @@ describe('ignore_file_extension', function() {
 
   it ('should ignore file extension when expand_keys == true', function(done) {
 
-    // Create a remote git repo.  Then, init a Repo object with property file validate
-    // that file are in the appropriate place in the Consul KV store without file extension.
+    // Initialize a Repo and commit a properties file. Validate that the
+    // expanded properties exist in the Consul KV store without a file
+    // extension.
     git_commands.init(git_utils.TEST_REMOTE_REPO, function(err) {
       if (err) return done(err);
 

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -17,6 +17,15 @@ var git_commands = require('../lib/git/commands.js');
 
 describe('ignore_file_extension', function() {
 
+  // Set up common configuration fixture.
+  var repo_config;
+  beforeEach(function(done) {
+    repo_config = git_utils.createRepoConfig();
+    repo_config.source_root = "src/main/resources";
+    repo_config.ignore_file_extension = true;
+    done();
+  });
+
   it ('should create folders on consul without file extension', function(done) {
 
     // Create a remote git repo.  Then, init a Repo object with property file validate
@@ -30,11 +39,9 @@ describe('ignore_file_extension', function() {
         git_utils.addFileToGitRepo("src/main/resources/user-service-dev.properties", "default.connection.pool.db.url=jdbc:mysql://db-host:3306/user", "User property file for dev environment added.", function(err) {
           if (err) return done(err);
 
-          var repo_config = git_utils.createRepoConfig();
-          repo_config.source_root = "src/main/resources";
           repo_config.expand_keys = true;
-          repo_config.ignore_file_extension = true;
           var repo = new Repo(repo_config);
+
           repo.init(function(err) {
             if (err) return done(err);
             consul_utils.validateValue('test_repo/master/user-service-dev/default.connection.pool.db.url', "jdbc:mysql://db-host:3306/user", function(err, value) {

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -33,6 +33,19 @@ describe('ignore_file_extension', function() {
     done();
   });
 
+  var test_files_known_extensions = {
+    'ignore_file_extension/config_yaml.yaml': 'foo: bar',
+    'ignore_file_extension/config_yml.yml': 'foo: bar',
+    'ignore_file_extension/config_json.json': '{"foo": "bar"}',
+    'ignore_file_extension/config_properties.properties': 'foo=bar',
+  };
+
+  var test_files_unknown_extensions = {
+    'ignore_file_extension/config_ini.ini': 'foo = bar',
+    'ignore_file_extension/config_toml.toml': 'foo = bar',
+  };
+
+
   it ('should ignore file extension when expand_keys == true', function(done) {
 
     // Initialize a Repo and commit a properties file. Validate that the
@@ -87,4 +100,69 @@ describe('ignore_file_extension', function() {
     });
   });
 
+  for (var filename in test_files_known_extensions) {
+    (function(filename) {
+      var contents = test_files_known_extensions[filename];
+      var key_name = filename.substr(0, filename.lastIndexOf('.'));
+      var extension = filename.substr(filename.lastIndexOf('.') + 1);
+      it ('should remove file extension for known file type: ' + extension, function(done) {
+
+        git_commands.init(git_utils.TEST_REMOTE_REPO, function(err) {
+          if (err) return done(err);
+
+          mkdirp(git_utils.TEST_REMOTE_REPO + 'ignore_file_extension', function(cb) {
+            if (err) return done(err);
+
+            git_utils.addFileToGitRepo(filename, contents, 'Test data added: ' + filename, function(err) {
+              if (err) return done(err);
+
+              repo_config.expand_keys = true;
+              var repo = new Repo(repo_config);
+
+              repo.init(function(err) {
+                if (err) return done(err);
+                consul_utils.validateValue('test_repo/master/' + key_name + '/foo', 'bar', function(err, value) {
+                  if (err) return done(err);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    })(filename);
+  }
+
+  for (var filename in test_files_unknown_extensions) {
+    (function(filename) {
+      var contents = test_files_unknown_extensions[filename];
+      var key_name = filename.substr(0, filename.lastIndexOf('.'));
+      var extension = filename.substr(filename.lastIndexOf('.') + 1);
+      it ('should not remove file extension for unknown file type: ' + extension, function(done) {
+
+        git_commands.init(git_utils.TEST_REMOTE_REPO, function(err) {
+          if (err) return done(err);
+
+          mkdirp(git_utils.TEST_REMOTE_REPO + 'ignore_file_extension', function(cb) {
+            if (err) return done(err);
+
+            git_utils.addFileToGitRepo(filename, contents, 'Test data added: ' + filename, function(err) {
+              if (err) return done(err);
+
+              repo_config.expand_keys = true;
+              var repo = new Repo(repo_config);
+
+              repo.init(function(err) {
+                if (err) return done(err);
+                consul_utils.validateValue('test_repo/master/' + key_name + '/foo', '', function(err, value) {
+                  if (err) return done(err);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    })(filename);
+  }
 });

--- a/test/git2consul_ignore_file_extension_test.js
+++ b/test/git2consul_ignore_file_extension_test.js
@@ -26,7 +26,7 @@ describe('ignore_file_extension', function() {
     done();
   });
 
-  it ('should create folders on consul without file extension', function(done) {
+  it ('should ignore file extension when expand_keys == true', function(done) {
 
     // Create a remote git repo.  Then, init a Repo object with property file validate
     // that file are in the appropriate place in the Consul KV store without file extension.


### PR DESCRIPTION
Prior to this patch, setting `ignore_file_extension` had two unexpected
effects:

  1. Any path containing `.` would be truncated
  2. Paths which did not include periods would simply be removed from the
     key/value store:

     ```
     > var file = 'foo/bar/baz';
     undefined
     > file = file.substr(0, file.lastIndexOf('.'));
     ''
     ```

This patch makes `ignore_file_extensions` less greedy. `create_key_name()` will
only remove the extension when:

  1. the extension matches `.json`, `.yaml`, `.yml`, or `.properties`, and
  2. `expand_keys` is enabled.

Closes #56.