### PR TITLE
Add support for the "support_tags" command when running with no hooks…

### DIFF
--- a/lib/git/commands.js
+++ b/lib/git/commands.js
@@ -1,4 +1,5 @@
 var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 
 var logger = require('../logging.js');
 
@@ -22,6 +23,18 @@ var run_command = function(cmd, cwd, cb) {
 
     cb(null, stdout);
   });
+};
+
+var run_command_sync = function(cmd, cwd, cb) {
+  logger.trace('Running synchronously %s in %s', cmd, cwd);
+  try {
+    var stdout = execSync(cmd, {cwd: cwd});
+    if (stdout.length > 0) logger.trace("stdout:\n" + stdout);
+    cb(null, stdout);
+  }
+  catch(err) {
+    cb(new Error(err));
+  }
 };
 
 exports.init = function(cwd, cb) {
@@ -62,6 +75,18 @@ exports.pull = function(branch_name, cwd, cb) {
 
 exports.extractTags = function (repo_url, cwd, cb) {
   run_command('git ls-remote --tags' + ' ' + repo_url, cwd, function (err, output) {
+    var extracted_tags = [];
+    var one_tag;
+    var tag_regex = /refs\/tags\/(.*)\^\{\}/ig;
+    while ((one_tag = tag_regex.exec(output)) !== null) {
+      extracted_tags.push(one_tag[1]);
+    }
+    cb(null, extracted_tags)
+  });
+}
+
+exports.extractTagsSync = function (repo_url, cwd, cb) {
+  run_command_sync('git ls-remote --tags' + ' ' + repo_url, cwd, function (err, output) {
     var extracted_tags = [];
     var one_tag;
     var tag_regex = /refs\/tags\/(.*)\^\{\}/ig;

--- a/lib/git/repo.js
+++ b/lib/git/repo.js
@@ -66,6 +66,21 @@ function Repo(repo_config) {
     // TODO: Switch to passing in the repo, not the repo_config.
     branches[branch] = new Branch(repo_config, branch);
   });
+
+  if (repo_config.support_tags === true) {
+    git_commands.extractTagsSync(this_obj.url, this_obj.repo_config.local_store, function (err, tags) {
+      if (err) throw new Error(err)
+
+      var new_tags = tags.filter(function (tag) {
+        return this_obj.branch_names.indexOf(tag) < 0
+      });
+
+      new_tags.forEach(function (tag_name) {
+        this_obj.branches[tag_name] = new Branch(repo_config, tag_name);
+        this_obj.branch_names.push(tag_name);
+      });
+    });
+  }
 }
 
 Repo.prototype.getBranch = function(branch_name) {


### PR DESCRIPTION
… or in "no daemon" mode.

I added a issue (#139) about "support_tags" not working in "no daemon" mode. I made a small change that gets it working. Not sure it is the optimal way to do it, but I leave it here for your perusal. 