### PR TITLE
updated --config_key to --config-key for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ There are environment variable equivalents for the parameters that git2consul ac
 
 ##### Alternate Config Locations
 
-By default, git2consul looks for its configuration at the Consul Key `git2consul/config`.  You can override this with a `-c` of `--config_key` command line switch, like so:
+By default, git2consul looks for its configuration at the Consul Key `git2consul/config`.  You can override this with a `-c` of `--config-key` command line switch, like so:
 
 ```sh
 git2consul -c git2consul/alternative_config

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ for (var i=2; i<process.argv.length; ++i) {
     global.endpoint = process.argv[i+1];
   }
 
-  if(process.argv[i] === '-c' || process.argv[i] === '--config-key') {
+  if(process.argv[i] === '-c' || process.argv[i] === '--config-key' || process.argv[i] === '--config_key') {
     if(i+1 >= process.argv.length) {
       logger.error("No consul Key name provided with --config-key option");
       process.exit(4);

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,9 @@ for (var i=2; i<process.argv.length; ++i) {
     global.endpoint = process.argv[i+1];
   }
 
-  if(process.argv[i] === '-c' || process.argv[i] === '--config_key') {
+  if(process.argv[i] === '-c' || process.argv[i] === '--config-key') {
     if(i+1 >= process.argv.length) {
-      logger.error("No consul Key name provided with --config_key option");
+      logger.error("No consul Key name provided with --config-key option");
       process.exit(4);
     }
     global.config_key = process.argv[i+1];

--- a/utils/config_seeder.js
+++ b/utils/config_seeder.js
@@ -32,9 +32,9 @@ for (var i=2; i<process.argv.length; ++i) {
       global.port = process.argv[i+1];
     }
 
-    if(process.argv[i] === '-c' || process.argv[i] === '--config_key') {
+    if(process.argv[i] === '-c' || process.argv[i] === '--config-key') {
       if(i+1 >= process.argv.length) {
-        logger.error("No consul Key name provided with --config_key option");
+        logger.error("No consul Key name provided with --config-key option");
         process.exit(3);
       }
       global.config_key = process.argv[i+1];

--- a/utils/config_seeder.js
+++ b/utils/config_seeder.js
@@ -32,7 +32,7 @@ for (var i=2; i<process.argv.length; ++i) {
       global.port = process.argv[i+1];
     }
 
-    if(process.argv[i] === '-c' || process.argv[i] === '--config-key') {
+    if(process.argv[i] === '-c' || process.argv[i] === '--config-key' || process.argv[i] === '--config_key') {
       if(i+1 >= process.argv.length) {
         logger.error("No consul Key name provided with --config-key option");
         process.exit(3);


### PR DESCRIPTION
`--config-file` command line option uses a `-` dash in the name and `--config_key` option currently uses an `_` underscore in the name.  Updated to `--config-key` so that both options consistently use a dash in the name.  