### PR TITLE
Fix directory permissions check for Windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var properties = require ("properties");
 
 /**
- * Check to make sure the provided path is a writeable directory.  Throw an exception if not.
+ * Check to make sure the provided path is a writable directory. Throw an exception if not.
  */
 module.exports.validate_writeable_directory = function(dir) {
   try {
@@ -11,15 +11,13 @@ module.exports.validate_writeable_directory = function(dir) {
     throw new Error('directory ' + dir + ' does not exist');
   }
 
-  // Check whether this owner or group or anyone is allowed to write the directory.
-  var can_write = ((process.getuid() === stat.uid) && (stat.mode & 00200)) || // User is owner and owner can write.
-                  ((process.getgid() === stat.gid) && (stat.mode & 00020)) || // User is in group and group can write.
-                  ((stat.mode & 00002)); // Anyone can write.
-  if (!can_write) {
-    throw new Error(dir + ' is not writeable');
+  // Check if this process is allowed to write into directory.
+  try {
+      fs.accessSync(dir, fs.constants.R_OK | fs.constants.W_OK);
+  } catch(e) {
+      throw new Error(dir + ' is not writable');
   }
 
-  //console.error(require('util').inspect(stat));
   if (!stat.isDirectory()) {
     throw new Error(dir + ' is not a directory');
   }


### PR DESCRIPTION
This PR fix issue with directory permissions check for Windows.

I plan to use this tool with Windows but current approach with process.getuid simply doesn't work. I guess this check will works well for both Linux and Window.