### PR TITLE
Remove file trimming

### DIFF
--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -180,7 +180,7 @@ var file_modified = function(branch, file, cb) {
       fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
         /* istanbul ignore if */
         if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
-        body = body ? body.trim() : '';
+        body = body || '';
         try {
           var obj = JSON.parse(body);
           populate_kvs_from_object(branch, create_key_name(branch, file), obj, kvs, cb);
@@ -227,7 +227,7 @@ var file_modified = function(branch, file, cb) {
     fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
-      body = body ? body.trim() : '';
+      body = body || '';
       try {
         var obj = yaml.safeLoad(body);
         populate_kvs_from_object(branch, create_key_name(branch, file), obj, kvs, cb);
@@ -242,7 +242,7 @@ var file_modified = function(branch, file, cb) {
     fs.readFile(fqf, {encoding: 'utf8'}, function (err, body) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + fqf + ' due to ' + err);
-      body = body ? body.trim() : '';
+      body = body || '';
       write_content_to_consul(create_key_name(branch, file), body, cb);
     });
   };


### PR DESCRIPTION
Remove file trimming as this can sometimes change the meaning of the file (eg in the case of yaml files where whitespace and indentation is important)