### PR TITLE
Add support for certificates for secure mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ There are environment variable equivalents for the parameters that git2consul ac
 * `CONSUL_ENDPOINT` maps to `-e` or `--endpoint`
 * `CONSUL_PORT` maps to `-p` or `--port`
 * `CONSUL_SECURE` maps to `-s` or `--secure`
+* `CONSUL_CERT` maps to `--cert`
+* `CONSUL_KEY` maps to `--key`
+* `CONSUL_CA` maps to `--ca`
 * `TOKEN` maps to `-t` or `--token`
 
 

--- a/lib/config_reader.js
+++ b/lib/config_reader.js
@@ -1,4 +1,4 @@
-var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure':global.secure});
+var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure':global.secure, 'cert': global.cert, 'key': global.key, 'ca': global.ca});
 
 var _ = require('underscore');
 

--- a/lib/config_seeder.js
+++ b/lib/config_seeder.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var _ = require('underscore');
 
-var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure': global.secure});
+var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure': global.secure, 'cert': global.cert, 'key': global.key, 'ca': global.ca});
 var logger = require('./logging.js');
 
 /**

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -6,7 +6,7 @@ var utils = require('../utils.js');
 
 var logger = require('../logging.js');
 
-var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure': global.secure});
+var consul = require('consul')({'host': global.endpoint, 'port': global.port, 'secure': global.secure, 'cert': global.cert, 'key': global.key, 'ca': global.ca});
 
 var token = undefined;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,9 @@ var os = require('os');
 global.endpoint = process.env.CONSUL_ENDPOINT || "127.0.0.1";
 global.port = process.env.CONSUL_PORT || 8500;
 global.secure = process.env.CONSUL_SECURE || false;
+global.cert_filename = process.env.CONSUL_CERT || '';
+global.key_filename = process.env.CONSUL_KEY || '';
+global.ca_filename = process.env.CONSUL_CA || '';
 global.token = process.env.TOKEN || null;
 global.config_file = null;
 global.config_key = "git2consul/config"
@@ -60,6 +63,43 @@ for (var i=2; i<process.argv.length; ++i) {
     }
     global.config_file = process.argv[i+1];
   }
+
+  if(process.argv[i] === '--cert') {
+    if(i+1 >= process.argv.length) {
+      logger.error("No file provided with --cert option");
+      process.exit(7);
+    }
+    global.cert_filename = process.argv[i+1];
+  }
+
+  if(process.argv[i] === '--key') {
+    if(i+1 >= process.argv.length) {
+      logger.error("No file provided with --key option");
+      process.exit(7);
+    }
+    global.key_filename = process.argv[i+1];
+  }
+
+  if(process.argv[i] === '--ca') {
+    if(i+1 >= process.argv.length) {
+      logger.error("No file provided with --ca option");
+      process.exit(7);
+    }
+    global.ca_filename = process.argv[i+1];
+  }
+}
+
+/**
+ * Read the certificate, key and CA files.
+ */
+if (global.cert_filename != '') {
+  global.cert = fs.readFileSync(global.cert_filename);
+}
+if (global.key_filename != '') {
+  global.key = fs.readFileSync(global.key_filename);
+}
+if (global.ca_filename != '') {
+  global.ca = fs.readFileSync(global.ca_filename);
 }
 
 var config_reader = require('./config_reader.js');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "body-parser": "~1.4.3",
     "bunyan": "1.1.3",
-    "consul": "^0.10.0",
+    "consul": "^0.29.0",
     "coveralls": "^2.11.2",
     "express": "~4.6.1",
     "mkdirp": "0.5.0",

--- a/utils/config_seeder.js
+++ b/utils/config_seeder.js
@@ -10,6 +10,9 @@ var logger = require('../lib/logging.js');
 global.endpoint = process.env.CONSUL_ENDPOINT || "127.0.0.1";
 global.port = process.env.CONSUL_PORT || 8500;
 global.secure = process.env.CONSUL_SECURE || false;
+global.cert_filename = process.env.CONSUL_CERT || '';
+global.key_filename = process.env.CONSUL_KEY || '';
+global.ca_filename = process.env.CONSUL_CA || '';
 global.token = process.env.TOKEN || null;
 global.config_key = "git2consul/config";
 


### PR DESCRIPTION
This allows for an optional Certifying Authority certificate as well as
a Client certificate and key for use with secure mode.  Allowing
git2consul to be used with servers that have verify_incoming turned on.

Consul client library had to be upgraded to pick up a new enough version
of the node consul client library and it's dependency papi to support
this.